### PR TITLE
Support credentials file

### DIFF
--- a/templates/default/config.erb
+++ b/templates/default/config.erb
@@ -1,16 +1,7 @@
 # Configuration for the awscli tool
 
-<% default_profile = @config_profiles['default']
-unless default_profile.nil? %>
-[default]
-<%  default_profile.each do |key, value| %>
-<%= key %> = <%= value %>
-<%  end
-end %>
-
-<% @config_profiles.each do |profile, options|
-next if profile=='default' %>
-[profile <%= profile %>]
+<% @config_profiles.each do |profile, options| %>
+[<% unless profile == "default" %>profile <% end %><%= profile %>]
 <%   options.each do |key, value| %>
 <%= key %> = <%= value %>
 <%   end %>

--- a/templates/default/credential.erb
+++ b/templates/default/credential.erb
@@ -1,0 +1,9 @@
+# Credentials for the awscli tool
+
+<% @credentials.each do |profile, options| %>
+[<%= profile %>]
+<%   options.each do |key, value| %>
+<%= key %> = <%= value %>
+<%   end %>
+<% end %>
+


### PR DESCRIPTION
`~/.aws/credentials` を作成できるようにします。
また合わせて以下の問題を修正します。

- ホームディレクトリが `/home` 以下固定になっている
- 複数のユーザを対象としている場合 `default` プロファイルが作れない問題

この変更により attributes の構造が変わります。