### PR TITLE
awscliのバージョン指定できるようにします。

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ For ubuntu and debian platforms, also installs command-ine completion for the `a
 
 Configuring
 ===========
+##### `[:awscli][:version]`
+The version of awscli tool
+Default: 1.16.38 ( last one that doesn't break cloud-init https://github.com/aws/aws-cli/issues/3678#issuecomment-433191412 )
 
 ##### `[:awscli][:compile_time]`
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default[:awscli][:compile_time] = false
 default[:awscli][:user] = "root"
+default[:awscli][:version] = "1.16.38"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,12 +2,12 @@
 
 case node[:platform]
 when 'debian', 'ubuntu'
-  file = '/usr/local/bin/aws'
-  cmd = 'apt-get install -y python-pip && pip install awscli'
+  file = "/usr/local/bin/aws"
+  cmd = "apt-get install -y python-pip && pip install awscli==#{node[:awscli][:version]}"
   completion_file = '/etc/bash_completion.d/aws'
 when 'redhat', 'centos', 'fedora', 'amazon', 'scientific'
-  file = '/usr/bin/aws'
-  cmd = 'yum -y install python-pip && pip install awscli'
+  file = "/usr/bin/aws"
+  cmd = "yum -y install python-pip && pip install awscli==#{node[:awscli][:version]}"
 end
 r = execute 'install awscli' do
   command cmd


### PR DESCRIPTION
#### 問題
新しいawscliとcloud-init相性が悪いため、cloud-initのコマンドが壊れました。
詳しく
aws/aws-cli#3678

#### 解決

chefでawscliバージョン指定できるようにして、awscli1.16.38がcloud-initと問題ないので、そのバージョンを使用します。